### PR TITLE
ET-30 LOTL source trust source

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,39 @@ public class Example3 {
         }
     }
 }
+```
 
+### PDF Validation using a List of Trusted Lists
+
+```java
+import gr.grnet.eseal.PDFValidator;
+import gr.grnet.eseal.LOTLTrustSource;
+import gr.grnet.eseal.ValidationLevel;
+import gr.grnet.eseal.ValidationReport;
+import gr.grnet.eseal.LOTLURL;
+public class Example4 {
+
+    public static void main( String[] args ) {
+
+        // Initialise the pdf validator from a file source
+        PDFValidator pdf = new PDFValidator("/path/to/pdf");
+
+
+        try {
+            
+            // Initialise the list of trusted list source from the european lotl
+            LOTLTrustSource lotlTrustSource = new LOTLTrustSource(LOTLURL.EUROPE);
+
+            // Validate the document based on the provided trust source(list of trusted lists) and the validation severity
+            ValidationReport r =  pdf.validate(ValidationLevel.BASIC_SIGNATURES, lotlTrustSource);
+
+            // get the result of the validation process
+            System.out.println(r.getValidationResult());
+
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+    }
+}
 ```
 

--- a/eseal/src/main/java/gr/grnet/eseal/LOTLTrustSource.java
+++ b/eseal/src/main/java/gr/grnet/eseal/LOTLTrustSource.java
@@ -1,0 +1,58 @@
+package gr.grnet.eseal;
+
+import static gr.grnet.eseal.TrustedListsUtils.*;
+
+import eu.europa.esig.dss.spi.x509.CommonCertificateSource;
+import eu.europa.esig.dss.tsl.function.OfficialJournalSchemeInformationURI;
+import eu.europa.esig.dss.tsl.job.TLValidationJob;
+import eu.europa.esig.dss.tsl.source.LOTLSource;
+import eu.europa.esig.dss.tsl.sync.AcceptAllStrategy;
+import java.util.Arrays;
+
+/**
+ * <p>
+ *     Trust source that will be supplied to the pdf validation process based on a list of trusted lists.
+ * </p>
+ */
+public class LOTLTrustSource {
+
+    private TLValidationJob job;
+    private static final String OJ_URL = "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv:OJ.C_.2019.276.01.0001.01.ENG";
+
+    /** Creates a trusted list trust source from the provided list of trusted lists.
+     * @param lotlurl enum of a lotl url
+     */
+    public LOTLTrustSource(LOTLURL lotlurl) {
+        this(lotlurl.toString());
+    }
+
+    /** Creates a trusted list trust source from the provided list of trusted trusted lists.
+     * @param url for the list of trusted lists.
+     */
+    public LOTLTrustSource(String url) {
+        this.job = this.buildSource(url);
+    }
+
+    public TLValidationJob getJob() {
+        return job;
+    }
+
+    private TLValidationJob buildSource(String url){
+            TLValidationJob job = new TLValidationJob();
+            job.setOfflineDataLoader(offlineLoader());
+            job.setOnlineDataLoader(onlineLoader());
+            job.setSynchronizationStrategy(new AcceptAllStrategy());
+            job.setCacheCleaner(cacheCleaner());
+
+            LOTLSource lotlSource = new LOTLSource();
+            lotlSource.setUrl(url);
+            lotlSource.setCertificateSource(new CommonCertificateSource());
+            lotlSource.setSigningCertificatesAnnouncementPredicate(new OfficialJournalSchemeInformationURI(OJ_URL));
+            lotlSource.setPivotSupport(true);;
+
+            job.setListOfTrustedListSources(lotlSource);
+            job.setLOTLAlerts(Arrays.asList(ojUrlAlert(lotlSource), lotlLocationAlert(lotlSource)));
+            job.setTLAlerts(Arrays.asList(tlSigningAlert(), tlExpirationDetection()));
+            return job;
+    }
+}

--- a/eseal/src/main/java/gr/grnet/eseal/LOTLURL.java
+++ b/eseal/src/main/java/gr/grnet/eseal/LOTLURL.java
@@ -1,0 +1,24 @@
+package gr.grnet.eseal;
+
+/**
+ * Enum that contains available lists of trusted lists.
+ *
+ * <p>
+ *     For example, {@link #EUROPE} contains the european list of trusted lists.
+ * </p>
+ */
+public enum LOTLURL {
+
+    EUROPE("https://ec.europa.eu/tools/lotl/eu-lotl.xml");
+
+    private final String name;
+
+    private LOTLURL(String s) {
+        name = s;
+    }
+
+    public String toString() {
+        return this.name;
+    }
+
+}

--- a/eseal/src/main/java/gr/grnet/eseal/PDFValidator.java
+++ b/eseal/src/main/java/gr/grnet/eseal/PDFValidator.java
@@ -101,6 +101,37 @@ public class PDFValidator {
     /**
      * Performs the validation process with the given trust source
      * @param validationLevel the level of validation severity
+     * @param lotlTrustSource the trust source that will be used to validate the document
+     * @return ValidationReport that contains information regarding the validation process
+     */
+    public ValidationReport validate(ValidationLevel validationLevel, LOTLTrustSource lotlTrustSource) {
+
+        TrustedListsCertificateSource trustedListsCertificateSource = new TrustedListsCertificateSource();
+
+        // build the certificate verifier for the pdf validator
+        CertificateVerifier cv =  new CommonCertificateVerifier();
+        CommonsDataLoader commonsDataLoader = new CommonsDataLoader();
+        cv.setCrlSource(new OnlineCRLSource());
+        cv.setOcspSource(new OnlineOCSPSource());
+        cv.setDataLoader(commonsDataLoader);
+        cv.setTrustedCertSources(trustedListsCertificateSource);
+
+        lotlTrustSource.getJob().setTrustedListCertificateSource(trustedListsCertificateSource);
+        lotlTrustSource.getJob().onlineRefresh();
+
+        // initialize the dss validator
+        PDFDocumentValidator dssValidator = new PDFDocumentValidator(this.pdfDocument);
+        dssValidator.setValidationLevel(determineLevel(validationLevel));
+        dssValidator.setCertificateVerifier(cv);
+
+        Reports r = dssValidator.validateDocument();
+
+        return new ValidationReport(r);
+    }
+
+    /**
+     * Performs the validation process with the given trust source
+     * @param validationLevel the level of validation severity
      * @param keystoreTrustSource the trust source that will be used to validate the document
      * @return ValidationReport that contains information regarding the validation process
      */

--- a/eseal/src/main/java/gr/grnet/eseal/TLTrustSource.java
+++ b/eseal/src/main/java/gr/grnet/eseal/TLTrustSource.java
@@ -1,21 +1,12 @@
 package gr.grnet.eseal;
 
-import eu.europa.esig.dss.service.http.commons.CommonsDataLoader;
-import eu.europa.esig.dss.service.http.commons.FileCacheDataLoader;
-import eu.europa.esig.dss.spi.client.http.DSSFileLoader;
-import eu.europa.esig.dss.spi.client.http.IgnoreDataLoader;
+import static gr.grnet.eseal.TrustedListsUtils.*;
+
 import eu.europa.esig.dss.spi.tsl.TrustedListsCertificateSource;
 import eu.europa.esig.dss.spi.x509.CommonCertificateSource;
-import eu.europa.esig.dss.tsl.alerts.TLAlert;
-import eu.europa.esig.dss.tsl.alerts.detections.TLExpirationDetection;
-import eu.europa.esig.dss.tsl.alerts.detections.TLSignatureErrorDetection;
-import eu.europa.esig.dss.tsl.alerts.handlers.log.LogTLExpirationAlertHandler;
-import eu.europa.esig.dss.tsl.alerts.handlers.log.LogTLSignatureErrorAlertHandler;
-import eu.europa.esig.dss.tsl.cache.CacheCleaner;
 import eu.europa.esig.dss.tsl.job.TLValidationJob;
 import eu.europa.esig.dss.tsl.source.TLSource;
 import eu.europa.esig.dss.tsl.sync.AcceptAllStrategy;
-import java.io.File;
 import java.util.Arrays;
 
 /**
@@ -28,6 +19,7 @@ public class TLTrustSource {
     private TLValidationJob job;
 
     /** Creates a trusted list trust source.
+     * @param trustedListURL enum of a trusted list url
      */
     public TLTrustSource(TrustedListURL trustedListURL) {
         this(trustedListURL.toString());
@@ -61,53 +53,5 @@ public class TLTrustSource {
 
         return job;
     }
-
-
-    private static DSSFileLoader onlineLoader() {
-        FileCacheDataLoader onlineFileLoader = new FileCacheDataLoader();
-        onlineFileLoader.setCacheExpirationTime(100);
-        onlineFileLoader.setDataLoader(new CommonsDataLoader());
-        onlineFileLoader.setFileCacheDirectory(tlCacheDirectory());
-
-        return onlineFileLoader;
-    }
-
-    private static File tlCacheDirectory() {
-        File rootFolder = new File(System.getProperty("java.io.tmpdir"));
-        File tslCache = new File(rootFolder, "dss-tsl-loader2");
-        if (tslCache.mkdirs()) {
-            System.out.println(tslCache.getAbsolutePath());
-        }
-        return tslCache;
-    }
-
-    private static TLAlert tlSigningAlert() {
-        TLSignatureErrorDetection signingDetection = new TLSignatureErrorDetection();
-        LogTLSignatureErrorAlertHandler handler = new LogTLSignatureErrorAlertHandler();
-        return new TLAlert(signingDetection, handler);
-    }
-
-    private static TLAlert tlExpirationDetection() {
-        TLExpirationDetection expirationDetection = new TLExpirationDetection();
-        LogTLExpirationAlertHandler handler = new LogTLExpirationAlertHandler();
-        return new TLAlert(expirationDetection, handler);
-    }
-
-    private static CacheCleaner cacheCleaner() {
-        CacheCleaner cacheCleaner = new CacheCleaner();
-        cacheCleaner.setCleanFileSystem(true);
-        cacheCleaner.setCleanMemory(true);
-        cacheCleaner.setDSSFileLoader(offlineLoader());
-        return cacheCleaner;
-    }
-
-    private static DSSFileLoader offlineLoader() {
-        FileCacheDataLoader offlineFileLoader = new FileCacheDataLoader();
-        offlineFileLoader.setDataLoader(new IgnoreDataLoader());
-        offlineFileLoader.setCacheExpirationTime(100);
-        offlineFileLoader.setFileCacheDirectory(tlCacheDirectory());
-        return offlineFileLoader;
-    }
-
 }
 

--- a/eseal/src/main/java/gr/grnet/eseal/TrustedListsUtils.java
+++ b/eseal/src/main/java/gr/grnet/eseal/TrustedListsUtils.java
@@ -1,0 +1,88 @@
+package gr.grnet.eseal;
+
+import eu.europa.esig.dss.service.http.commons.CommonsDataLoader;
+import eu.europa.esig.dss.service.http.commons.FileCacheDataLoader;
+import eu.europa.esig.dss.spi.client.http.DSSFileLoader;
+import eu.europa.esig.dss.spi.client.http.IgnoreDataLoader;
+import eu.europa.esig.dss.tsl.alerts.LOTLAlert;
+import eu.europa.esig.dss.tsl.alerts.TLAlert;
+import eu.europa.esig.dss.tsl.alerts.detections.LOTLLocationChangeDetection;
+import eu.europa.esig.dss.tsl.alerts.detections.OJUrlChangeDetection;
+import eu.europa.esig.dss.tsl.alerts.detections.TLExpirationDetection;
+import eu.europa.esig.dss.tsl.alerts.detections.TLSignatureErrorDetection;
+import eu.europa.esig.dss.tsl.alerts.handlers.log.LogLOTLLocationChangeAlertHandler;
+import eu.europa.esig.dss.tsl.alerts.handlers.log.LogOJUrlChangeAlertHandler;
+import eu.europa.esig.dss.tsl.alerts.handlers.log.LogTLExpirationAlertHandler;
+import eu.europa.esig.dss.tsl.alerts.handlers.log.LogTLSignatureErrorAlertHandler;
+import eu.europa.esig.dss.tsl.cache.CacheCleaner;
+import eu.europa.esig.dss.tsl.source.LOTLSource;
+
+import java.io.File;
+
+/**
+ * <p>
+ *     TrustedListsUtils provided various static methods for the configuration of a trusted list
+ *     and a list of trusted lists.
+ * </p>
+ */
+public class TrustedListsUtils {
+
+    public static DSSFileLoader onlineLoader() {
+        FileCacheDataLoader onlineFileLoader = new FileCacheDataLoader();
+        onlineFileLoader.setCacheExpirationTime(100);
+        onlineFileLoader.setDataLoader(new CommonsDataLoader());
+        onlineFileLoader.setFileCacheDirectory(tlCacheDirectory());
+
+        return onlineFileLoader;
+    }
+
+    public static File tlCacheDirectory() {
+        File rootFolder = new File(System.getProperty("java.io.tmpdir"));
+        File tslCache = new File(rootFolder, "dss-tsl-loader2");
+        if (tslCache.mkdirs()) {
+            System.out.println(tslCache.getAbsolutePath());
+        }
+        return tslCache;
+    }
+
+    public static CacheCleaner cacheCleaner() {
+        CacheCleaner cacheCleaner = new CacheCleaner();
+        cacheCleaner.setCleanFileSystem(true);
+        cacheCleaner.setCleanMemory(true);
+        cacheCleaner.setDSSFileLoader(offlineLoader());
+        return cacheCleaner;
+    }
+
+    public static DSSFileLoader offlineLoader() {
+        FileCacheDataLoader offlineFileLoader = new FileCacheDataLoader();
+        offlineFileLoader.setDataLoader(new IgnoreDataLoader());
+        offlineFileLoader.setCacheExpirationTime(100);
+        offlineFileLoader.setFileCacheDirectory(tlCacheDirectory());
+        return offlineFileLoader;
+    }
+
+    public static TLAlert tlSigningAlert() {
+        TLSignatureErrorDetection signingDetection = new TLSignatureErrorDetection();
+        LogTLSignatureErrorAlertHandler handler = new LogTLSignatureErrorAlertHandler();
+        return new TLAlert(signingDetection, handler);
+    }
+
+    public static TLAlert tlExpirationDetection() {
+        TLExpirationDetection expirationDetection = new TLExpirationDetection();
+        LogTLExpirationAlertHandler handler = new LogTLExpirationAlertHandler();
+        return new TLAlert(expirationDetection, handler);
+    }
+
+    public static LOTLAlert ojUrlAlert(LOTLSource source) {
+        OJUrlChangeDetection ojUrlDetection = new OJUrlChangeDetection(source);
+        LogOJUrlChangeAlertHandler handler = new LogOJUrlChangeAlertHandler();
+        return new LOTLAlert(ojUrlDetection, handler);
+    }
+
+    public static LOTLAlert lotlLocationAlert(LOTLSource source) {
+        LOTLLocationChangeDetection lotlLocationDetection = new LOTLLocationChangeDetection(source);
+        LogLOTLLocationChangeAlertHandler handler = new LogLOTLLocationChangeAlertHandler();
+        return new LOTLAlert(lotlLocationDetection, handler);
+    }
+
+}

--- a/eseal/src/test/java/gr/grnet/eseal/TestPDFValidator.java
+++ b/eseal/src/test/java/gr/grnet/eseal/TestPDFValidator.java
@@ -192,4 +192,26 @@ public class TestPDFValidator {
         Assert.assertArrayEquals("Expected detailed warnings", warnings, vr.getWarnings());
         Assert.assertArrayEquals("Expected detailed errors", errors, vr.getErrors());
     }
+
+    @Test
+    public void testValidateWithLOTLTrustSourceTotalPASS() {
+
+        PDFValidator pdfValidator = new PDFValidator(TestPDFValidator.class.getResource(testPDFpath).getFile());
+
+        LOTLTrustSource lotlTrustSource = new LOTLTrustSource(LOTLURL.EUROPE);
+
+        ValidationReport vr = pdfValidator.validate(gr.grnet.eseal.ValidationLevel.BASIC_SIGNATURES, lotlTrustSource);
+        String[] errors = new String[]{};
+        String[] warnings = new String[]{
+                "The certificate is not for eSig at issuance time!",
+                "The private key does not reside in a QSCD at issuance time!",
+                "The certificate is not for eSig at (best) signing time!",
+                "The private key does not reside in a QSCD at (best) signing time!",
+                "The trusted list is not well signed!",
+                "The signer's certificate does not have an expected key-usage!"
+        };
+        assertEquals(ValidationResult.TOTAL_PASSED, vr.getValidationResult());
+        Assert.assertArrayEquals("Expected detailed warnings", warnings, vr.getWarnings());
+        Assert.assertArrayEquals("Expected detailed errors", errors, vr.getErrors());
+    }
 }


### PR DESCRIPTION
Provide the implementation of a list of trusted lists trust source.
The list of trusted lists can be found in an URL in XML format.
The list of trusted lists implementation defaults to the european trusted list but can be configured for any trusted list through a URL.